### PR TITLE
Provide a dependencyManagement entry so that we can align to the correct productized camel for camel-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <camel4.8-version>4.8.0</camel4.8-version>
         <camel4.9-version>4.9.0</camel4.9-version>
 
-        <camel-version>${project.version}</camel-version>
+        <camel-version>4.10.3.redhat-00002</camel-version>
         <camel-spring-boot-version>4.10.3.redhat-00001</camel-spring-boot-version>
 
         <rewrite-recipe-bom.version>3.0.2</rewrite-recipe-bom.version>
@@ -136,7 +136,12 @@
                 <version>${camel-spring-boot-version}</version>
                 <type>pom</type>
             </dependency>
-
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-parent</artifactId>
+                <version>${camel-version}</version>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
camel-version being set to project.version won't work for a PNC build - we need camel-version to align to the last productized camel version