### PR TITLE
Change camel-spring-boot-version to 4.14.0.redhat-00006

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <camel4.12-version>4.12.0</camel4.12-version>
 
         <camel-version>4.14.0.redhat-00004</camel-version>
-        <camel-spring-boot-version>${project.version}</camel-spring-boot-version>
+        <camel-spring-boot-version>4.14.0.redhat-00006</camel-spring-boot-version>
 
         <!-- versions for camel-spring-boot -->
         <spring-boot-version>3.5.5</spring-boot-version>


### PR DESCRIPTION
Upstream this is ${project.version} to match the version of the camel-upgrade-recipes with camel/camel-spring-boot but downstream we need the version of camel-spring-boot to be distinct